### PR TITLE
Update package.json with .cql extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # logscale-syntax
 
-A VS Code extension for for LogScale Query Language (formerly Humio) syntax highlighting.
+A VS Code extension for for LogScale (CrowdStrike) Query Language (formerly Humio) syntax highlighting.
 
 ## Features
 
-- Syntax highlighting for `.logscale`, `.lql`, or `.humio` files. Plain and simple.
+- Syntax highlighting for `.logscale`, `.cql`, `.lql`, or `.humio` files. Plain and simple.
 - Full language functions support up to LogScale version 1.159.1.
 
 ![screenshot](images/demo_dark_modern.png)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "extensions": [
           ".lql",
           ".logscale",
-          ".humio"
+          ".humio",
+          ".cql"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
adding `.cql` extension as CrowdStrike is now referring to it as "CrowdStrike Query Language" when publishing contextual queries for NGSIEM and in the Falcon CAO Intel downloadable file extensions. 

note: https://library.humio.com/data-analysis/syntax.html

Examples: 
CrowdStrike_CSA_241377_Indicators.cql
CrowdStrike_CSA_24600_Indicators.cql
CrowdStrike_CSIT-24141_02.cql
CrowdStrike_CSIT-24257_01.cql